### PR TITLE
Create slack design standard for Slack Notifications

### DIFF
--- a/ckanext/notify/controllers/ui_controller.py
+++ b/ckanext/notify/controllers/ui_controller.py
@@ -270,11 +270,11 @@ class DataRequestsNotifyUI(base.BaseController):
                             'datarequest_title': result['title'],
                             'datarequest_description': result['description'],
                         }
-            slack_message = {'text': base.render_jinja2('notify/slack/{}.txt'.format(template), extra_vars)}
+            slack_message = base.render_jinja2('notify/slack/{}.txt'.format(template), extra_vars)
 
             for channel in channels:
                 requests.post(
-                    channel['webhook_url'], data=json.dumps(slack_message),
+                    channel['webhook_url'], data=(slack_message),
                     headers={'Content-type': 'application/json'}
                 )
 

--- a/ckanext/notify/templates/notify/slack/datarequest_close.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close.txt
@@ -1,4 +1,4 @@
-{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nIt appears you neglected your duties, a datarequest has been closed on {{ site_title }}. :sob:\n\n",
+{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nThe datarequest {{ datatrequest_title }} has been closed on {{ site_title }}. :sob:\n\n",
     "username": "datarequests-bot",
     "icon_emoji": ":monkey_face:",
     "attachments": [

--- a/ckanext/notify/templates/notify/slack/datarequest_close.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close.txt
@@ -1,3 +1,24 @@
-DataRequest {{ datarequest_title }} has been closed on {{ site_title }}.
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nIt appears you neglected your duties, a datarequest has been closed on {{ site_title }}. :sob:\n\n",
+    "username": "datarequests-bot",
+    "icon_emoji": ":monkey_face:",
+    "attachments": [
+        {
+            "color": "danger",
+            "title": "Click me to view the closed datarequest",
+            "title_link": "{{ datarequest_url }}",
+            "text": "Datarequest description: {{ datarequest_description }}",
+            "thumb_url": "https://media.giphy.com/media/2rtQMJvhzOnRe/giphy.gif",
+            "fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+        }
+    ]}

--- a/ckanext/notify/templates/notify/slack/datarequest_close.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_close.txt
@@ -1,4 +1,4 @@
-{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nThe datarequest {{ datatrequest_title }} has been closed on {{ site_title }}. :sob:\n\n",
+{"text": "*[CLOSED] Datarequest closed on the Organization: {{ site_title }}*\n\nThe datarequest {{ datatrequest_title }} has been closed on {{ site_title }}. :white_check_mark:\n\n",
     "username": "datarequests-bot",
     "icon_emoji": ":monkey_face:",
     "attachments": [

--- a/ckanext/notify/templates/notify/slack/datarequest_comment.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_comment.txt
@@ -1,5 +1,24 @@
-A comment has been made on a DataRequest to your organization on {{ site_title }}.
-
-Title: {{ datarequest_title }}
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[COMMENT] A new comment has been made on a datarequest made to the Organization: {{ site_title }}*\n\nYou should probably head over there and check it out! :running:\n\n",
+    "username": "datarequests-bot",
+    "icon_emoji": ":monkey_face:",
+    "attachments": [
+        {
+            "color": "warning",
+            "title": "Click me to view the comment",
+            "title_link": "{{ datarequest_url }}",
+            "text": "Datarequest description: {{ datarequest_description }}",
+            "thumb_url": "https://media.giphy.com/media/26xBNjd32hiIE4UpO/giphy.gif",
+            "fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+        }
+    ]}

--- a/ckanext/notify/templates/notify/slack/datarequest_create.txt
+++ b/ckanext/notify/templates/notify/slack/datarequest_create.txt
@@ -1,7 +1,24 @@
-A new DataRequest has been created on {{ site_title }}:
-
-Title: {{ datarequest_title }}
-
-Description: {{ datarequest_description }}
-
-<{{ datarequest_url }}|Click here> to view!
+{"text": "*[NEW DATAREQUEST] Created on the Organization: {{ site_title }}*\n\nIt appears you have work to do, a new datarequest has been created on {{ site_title }}. :ghost:\n\n",
+	"username": "datarequests-bot",
+	"icon_emoji": ":monkey_face:",
+	"attachments": [
+		{
+			 "color": "#36a64f",
+			"title": "Click me to view the new datarequest",
+            "title_link": "{{ datarequest_url }}",
+			"text": "Datarequest description: {{ datarequest_description }}",
+			"thumb_url": "https://media.giphy.com/media/3o6Ei2uhPW2eRv4c8M/giphy.gif",
+			"fields": [
+                {
+                    "title": "Datarequest title",
+                    "value": "{{ datarequest_title }}",
+                    "short": true
+                },
+                {
+                    "title": "Organization",
+                    "value": "{{ site_title }}",
+                    "short": true
+                }
+            ]
+		}
+	]}


### PR DESCRIPTION
#### What does this PR do?
Creates a design standard for slack notifications sent when actions are carried out on a datarequest i.e. a new comment, a new datarequest or a closed datarequest

#### Description of Task to be completed?
Users look for certain cues before reading anything. We should make it easy for users to immediately know whether they are looking at a new data requests, a comment, or closing.

Some things we can do to improve improve the user experience with Slack notifications:
- Add clear title in message e.g [COMMENT] , [NEW DATAREQUEST] [CLOSED]
- Clarity in sender's name
- Use emojis for the profile pic, title, description et al. (can also increase the fun in the notifications)
- Use Slack color options.

- Related to #10 .

#### How should this be manually tested?
- Set up slack channel notifications on your organization
- Create a new datarequest and check for a notification in the slack notification channel(s) you've set up
- Comment on a datarequest and check for a notification in the slack notification channel(s) you've set up
- Close a datarequest and check for a notification in the slack notification channel(s) you've set up

#### What are the relevant issues?
#10 

#### Screenshots (if appropriate)
<img width="848" alt="screen shot 2017-11-09 at 11 38 40" src="https://user-images.githubusercontent.com/11648960/32596327-f85537a6-c543-11e7-9228-2f2312fb3d2d.png">
